### PR TITLE
Add user prompt for clone, checkout, or both actions

### DIFF
--- a/clone_repos.sh
+++ b/clone_repos.sh
@@ -1,31 +1,58 @@
 #!/bin/bash
 
-# Prompt the user for the branch name
-read -p "Enter the branch name you want to checkout: " branch_name
+# Function to clone repositories
+clone_repositories() {
+  gh repo clone git@github.com:vrsoftbr/VRMaster.git
+  gh repo clone git@github.com:vrsoftbr/VRConnect.git
+  gh repo clone git@github.com:vrsoftbr/VRCore.git
+  gh repo clone git@github.com:vrsoftbr/VRNFe.git
+  gh repo clone git@github.com:vrsoftbr/VRFramework.git
+  gh repo clone git@github.com:vrsoftbr/VRWorkflow.git
+}
 
-# Clone the repositories
-gh repo clone git@github.com:vrsoftbr/VRMaster.git
-gh repo clone git@github.com:vrsoftbr/VRConnect.git
-gh repo clone git@github.com:vrsoftbr/VRCore.git
-gh repo clone git@github.com:vrsoftbr/VRNFe.git
-gh repo clone git@github.com:vrsoftbr/VRFramework.git
-gh repo clone git@github.com:vrsoftbr/VRWorkflow.git
+# Function to checkout branch in all repositories
+checkout_branch() {
+  read -p "Digite o nome do branch que você deseja fazer checkout: " branch_name
 
-# Navigate into each repository and checkout the specified branch
-cd VRMaster
-git checkout $branch_name
+  cd VRMaster
+  git checkout $branch_name
 
-cd ../VRConnect
-git checkout $branch_name
+  cd ../VRConnect
+  git checkout $branch_name
 
-cd ../VRCore
-git checkout $branch_name
+  cd ../VRCore
+  git checkout $branch_name
 
-cd ../VRNFe
-git checkout $branch_name
+  cd ../VRNFe
+  git checkout $branch_name
 
-cd ../VRFramework
-git checkout $branch_name
+  cd ../VRFramework
+  git checkout $branch_name
 
-cd ../VRWorkflow
-git checkout $branch_name
+  cd ../VRWorkflow
+  git checkout $branch_name
+}
+
+# Prompt the user for the desired action
+echo "O que você deseja fazer?"
+echo "1. Clonar repositórios"
+echo "2. Fazer checkout do branch em todos os repositórios"
+echo "3. Clonar repositórios e depois fazer checkout do branch em todos os repositórios"
+read -p "Digite o número da sua escolha: " choice
+
+case $choice in
+  1)
+    clone_repositories
+    ;;
+  2)
+    checkout_branch
+    ;;
+  3)
+    clone_repositories
+    checkout_branch
+    ;;
+  *)
+    echo "Escolha inválida. Saindo."
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Add user prompt for desired action in `clone_repos.sh`.

* Add a prompt to ask the user what they want to do: clone repositories, checkout all repositories, or both.
* Add a case statement to handle the user's choice.
* Move the repository cloning code into a function `clone_repositories`.
* Move the branch checkout code into a function `checkout_branch`.
* Translate user prompts to Portuguese.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LoriaLawrenceZ/clone-repos/pull/1?shareId=3271133b-295e-4e12-bb08-1651655b3241).