### PR TITLE
Add script to download .jar file from Google bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 This repository is empty. Any task executed on it should be considered a new capability and needs to be created.
+
+## download_jar.sh
+
+The `download_jar.sh` script is used to download a specific `.jar` file from a Google bucket.
+
+### How to run the script
+
+1. Ensure you have `gsutil` installed and configured on your system.
+2. Open a terminal.
+3. Navigate to the directory containing the `download_jar.sh` script.
+4. Run the script using the following command:
+   ```
+   ./download_jar.sh
+   ```
+5. The script will download the specified `.jar` file from the Google bucket and inform you when the download is complete.
+
+### How to install gsutil
+
+If you do not have `gsutil` installed, you can install it by following these steps:
+
+1. Install the Google Cloud SDK by following the instructions at https://cloud.google.com/sdk/docs/install.
+2. After installing the SDK, run the following command to install `gsutil`:
+   ```
+   gcloud components install gsutil
+   ```
+3. Verify the installation by running:
+   ```
+   gsutil version
+   ```

--- a/download_jar.sh
+++ b/download_jar.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Check if gsutil is installed
+if ! command -v gsutil &> /dev/null
+then
+    echo "gsutil could not be found. Would you like to install it? (yes/no)"
+    read install_gsutil
+    if [ "$install_gsutil" == "yes" ]; then
+        # Install gsutil
+        curl https://sdk.cloud.google.com | bash
+        exec -l $SHELL
+        gcloud components install gsutil
+    else
+        echo "Please install gsutil before running this script."
+        exit
+    fi
+fi
+
+# Download the .jar file from the Google bucket
+gsutil cp gs://<bucket-name>/<file-name>.jar .
+
+# Inform the user that the download is complete
+echo "Download complete."


### PR DESCRIPTION
Add `download_jar.sh` script to download a specific `.jar` file from a Google bucket and update `README.md` with instructions.

* **download_jar.sh**
  - Add a shebang line `#!/bin/bash`.
  - Check if `gsutil` is installed, and if not, prompt the user to install it.
  - Install `gsutil` if the user agrees.
  - Download the `.jar` file from the Google bucket using `gsutil cp`.
  - Inform the user that the download is complete.

* **README.md**
  - Add a section to explain the purpose of the `download_jar.sh` script.
  - Provide instructions on how to run the `download_jar.sh` script.
  - Add instructions on how to install `gsutil` if it is not already installed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LoriaLawrenceZ/clone-repos/pull/2?shareId=3735cd76-0772-4f01-8d2b-480bc6a368a6).