### PR TITLE
Update download_jar.sh to use vr_4_4 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The `download_jar.sh` script is used to download a specific `.jar` file from a G
    ```
    ./download_jar.sh
    ```
-5. The script will download the specified `.jar` file from the Google bucket and inform you when the download is complete.
+5. The script will download the specified `.jar` file from the Google bucket `vr_4_4` and inform you when the download is complete.
 
 ### How to install gsutil
 

--- a/download_jar.sh
+++ b/download_jar.sh
@@ -17,7 +17,7 @@ then
 fi
 
 # Download the .jar file from the Google bucket
-gsutil cp gs://<bucket-name>/<file-name>.jar .
+gsutil cp gs://vr_4_4/VRMaster.jar .
 
 # Inform the user that the download is complete
 echo "Download complete."


### PR DESCRIPTION
Update `download_jar.sh` and `README.md` to download the jar file from the specified bucket.

* **download_jar.sh**
  - Update the `gsutil cp` command to use the bucket name `vr_4_4` and the actual jar file name `VRMaster.jar`.

* **README.md**
  - Update the instructions to specify the bucket name `vr_4_4` and inform the user that the script will download the specified `.jar` file from this bucket.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LoriaLawrenceZ/clone-repos/pull/3?shareId=9baa1c18-6b61-4859-8ba2-d0dcfebc299c).