### PR TITLE
Fix Python check in download_jar.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,27 @@ The `download_jar.sh` script is used to download a specific `.jar` file from a G
 ### How to run the script
 
 1. Ensure you have `gsutil` installed and configured on your system.
-2. Open a terminal.
-3. Navigate to the directory containing the `download_jar.sh` script.
-4. Run the script using the following command:
+2. Ensure you have Python installed on your system.
+3. Open a terminal.
+4. Navigate to the directory containing the `download_jar.sh` script.
+5. Run the script using the following command:
    ```
    ./download_jar.sh
    ```
-5. The script will download the specified `.jar` file from the Google bucket `vr_4_4` and inform you when the download is complete.
+6. The script will download the specified `.jar` file from the Google bucket `vr_4_4` and inform you when the download is complete.
+
+### How to install Python
+
+If you do not have Python installed, you can install it by following these steps:
+
+1. Open the Microsoft Store.
+2. Search for "Python".
+3. Select the latest version of Python and click "Get" to install it.
+4. Follow the on-screen instructions to complete the installation.
+5. Verify the installation by running:
+   ```
+   python --version
+   ```
 
 ### How to install gsutil
 

--- a/download_jar.sh
+++ b/download_jar.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Check if Python is installed
+if ! command -v python &> /dev/null
+then
+    echo "Python could not be found. Would you like to install it? (yes/no)"
+    read install_python
+    if [ "$install_python" == "yes" ]; then
+        echo "Please install Python from the Microsoft Store or disable this shortcut from Settings > Manage App Execution Aliases."
+        exit
+    else
+        echo "Please install Python before running this script."
+        exit
+    fi
+fi
+
 # Check if gsutil is installed
 if ! command -v gsutil &> /dev/null
 then


### PR DESCRIPTION
Add a check for Python installation in `download_jar.sh` and update `README.md` with Python installation instructions.

* **download_jar.sh**
  - Add a check for Python installation at the beginning of the script.
  - Prompt the user to install Python if not found.
  - Provide instructions to install Python from the Microsoft Store if not found.

* **README.md**
  - Add a section on how to install Python if not found.
  - Update the instructions to include the new Python installation step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LoriaLawrenceZ/clone-repos/pull/4?shareId=d29bc3b6-da8f-48eb-8093-2beb95164f46).