### PR TITLE
Add git clone fallback if gh is not installed

### DIFF
--- a/clone_repos.sh
+++ b/clone_repos.sh
@@ -2,12 +2,22 @@
 
 # Function to clone repositories
 clone_repositories() {
-  gh repo clone git@github.com:vrsoftbr/VRMaster.git
-  gh repo clone git@github.com:vrsoftbr/VRConnect.git
-  gh repo clone git@github.com:vrsoftbr/VRCore.git
-  gh repo clone git@github.com:vrsoftbr/VRNFe.git
-  gh repo clone git@github.com:vrsoftbr/VRFramework.git
-  gh repo clone git@github.com:vrsoftbr/VRWorkflow.git
+  if command -v gh &> /dev/null
+  then
+    gh repo clone git@github.com:vrsoftbr/VRMaster.git
+    gh repo clone git@github.com:vrsoftbr/VRConnect.git
+    gh repo clone git@github.com:vrsoftbr/VRCore.git
+    gh repo clone git@github.com:vrsoftbr/VRNFe.git
+    gh repo clone git@github.com:vrsoftbr/VRFramework.git
+    gh repo clone git@github.com:vrsoftbr/VRWorkflow.git
+  else
+    git clone git@github.com:vrsoftbr/VRMaster.git
+    git clone git@github.com:vrsoftbr/VRConnect.git
+    git clone git@github.com:vrsoftbr/VRCore.git
+    git clone git@github.com:vrsoftbr/VRNFe.git
+    git clone git@github.com:vrsoftbr/VRFramework.git
+    git clone git@github.com:vrsoftbr/VRWorkflow.git
+  fi
 }
 
 # Function to checkout branch in all repositories


### PR DESCRIPTION
Add a conditional to check if `gh` is installed and use `git clone` if not.

* Check if `gh` is installed using `command -v gh &> /dev/null`
* If `gh` is installed, use `gh repo clone` to clone repositories
* If `gh` is not installed, use `git clone` to clone repositories

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LoriaLawrenceZ/clone-repos/pull/5?shareId=26130a14-46b9-400e-9526-02e8189e859b).