### PR TITLE
Set upstream for branches when creating or checking out

### DIFF
--- a/clone_repos.sh
+++ b/clone_repos.sh
@@ -82,21 +82,27 @@ create_branch() {
   read -p "New branch name: " new_branch_name
   cd VRMaster
   git checkout -b $new_branch_name $create_branch_name
+  git push --set-upstream origin $new_branch_name
 
   cd ../VRConnect
   git checkout -b $new_branch_name $create_branch_name
+  git push --set-upstream origin $new_branch_name
 
   cd ../VRCore
   git checkout -b $new_branch_name $create_branch_name
+  git push --set-upstream origin $new_branch_name
 
   cd ../VRNFe
   git checkout -b $new_branch_name $create_branch_name
+  git push --set-upstream origin $new_branch_name
 
   cd ../VRFramework
   git checkout -b $new_branch_name $create_branch_name
+  git push --set-upstream origin $new_branch_name
 
   cd ../VRWorkflow
   git checkout -b $new_branch_name $create_branch_name
+  git push --set-upstream origin $new_branch_name
 }
 
 # Function to update local branches from remote using its upstream or another branch


### PR DESCRIPTION
Add upstream setting when creating new branches in `clone_repos.sh`.

* Modify the `create_branch` function to include `git push --set-upstream origin $new_branch_name` after creating a new branch for each repository.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LoriaLawrenceZ/clone-repos/pull/7?shareId=60631e45-a3c0-4353-978c-0844fea3338a).