### PR TITLE
Add option to list altered archives in clone_repos.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The script now includes the following new features:
 2. **Header and Footer**: The script prints a header with a title at the beginning and a footer with a message at the end, providing a more structured and professional look.
 3. **Centralized and Captivating Prompts**: The prompt messages have been updated to be more centralized and captivating, enhancing the user experience.
 4. **Verbose Output**: The script now displays more verbose output during operations, including showing the affected repository in a different color.
+5. **List Altered Archives**: The script now includes an option to list altered archives and their status (added or not to the stage) and the repository location.
 
 ### How to run the script
 
@@ -74,3 +75,4 @@ The script now includes the following new features:
 4. To pull all changes from upstream, select option `[4] Pull all changes from upstream`.
 5. To create a new branch from an existing one, select option `[5] Create new branch from existing one` and enter the branch name when prompted.
 6. To update a local branch from remote, select option `[6] Update local branch from remote` and enter the branch name when prompted.
+7. To list altered archives and their status, select option `[7] List altered archives and their status`.

--- a/clone_repos.sh
+++ b/clone_repos.sh
@@ -174,6 +174,16 @@ update_branch() {
   git pull origin $update_branch_name
 }
 
+# Function to list altered archives and their status
+list_altered_archives() {
+  for repo in VRMaster VRConnect VRCore VRNFe VRFramework VRWorkflow; do
+    echo -e "\033[1;36mListing altered archives in $repo repository...\033[0m"
+    cd $repo
+    git status --short
+    cd ..
+  done
+}
+
 # Print header
 print_header
 
@@ -185,6 +195,7 @@ echo -e "\033[1;33m[3] Clone and checkout branch in repositories\033[0m"
 echo -e "\033[1;33m[4] Pull all changes from upstream\033[0m"
 echo -e "\033[1;33m[5] Create new branch from existing one\033[0m"
 echo -e "\033[1;33m[6] Update local branch from remote\033[0m"
+echo -e "\033[1;33m[7] List altered archives and their status\033[0m"
 read -p "Enter the number of your choice: " choice
 
 case $choice in
@@ -210,6 +221,9 @@ case $choice in
   6)
     ask_update_branch
     update_branch
+    ;;
+  7)
+    list_altered_archives
     ;;
   *)
     echo -e "\033[1;31mInvalid choice. Exiting.\033[0m"


### PR DESCRIPTION
Add an option to list altered archives and their status in `clone_repos.sh`.

* Add a new function `list_altered_archives` to list altered archives and their status.
* Add a new option `[7] List altered archives and their status` to the main menu.
* Update the `README.md` file to include instructions on how to use the new feature.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LoriaLawrenceZ/clone-repos/pull/10?shareId=75ab313e-b340-42a9-8090-952733298165).