### PR TITLE
Enhance list altered archives with color formatting

### DIFF
--- a/clone_repos.sh
+++ b/clone_repos.sh
@@ -179,7 +179,12 @@ list_altered_archives() {
   for repo in VRMaster VRConnect VRCore VRNFe VRFramework VRWorkflow; do
     echo -e "\033[1;36mListing altered archives in $repo repository...\033[0m"
     cd $repo
-    git status --short
+    git status --short | while read -r line; do
+      path=$(echo $line | awk '{print $2}')
+      archive=$(basename $path)
+      dir=$(dirname $path)
+      echo -e "\033[1;30m$dir/\033[0m\033[1;37m$archive\033[0m"
+    done
     cd ..
   done
 }


### PR DESCRIPTION
Modify the `list_altered_archives` function in `clone_repos.sh` to include color formatting for the path and archive name.

* Use `git status --short` to list the altered archives and apply color formatting to the output.
* Display the path to the archive in gray and the archive name in white for better contrast.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LoriaLawrenceZ/clone-repos/pull/11?shareId=5dce088a-2bca-4a2b-81e0-cfb2fcf7a9d3).